### PR TITLE
Handle cases where `message_args` is a list.

### DIFF
--- a/sublime_python.py
+++ b/sublime_python.py
@@ -198,7 +198,7 @@ class PythonCheckSyntaxListener(sublime_plugin.EventListener):
         lineno = view.rowcol(view.sel()[0].end())[0] + 1
         if lineno in errors_by_line:
             view.set_status('sublimepython-errors', '; '.join(
-                [m['message'] % m['message_args']
+                [m['message'] % tuple(m['message_args'])
                 for m in errors_by_line[lineno]]
             ))
         else:


### PR DESCRIPTION
This can be reproduced by redefining a variable in a list comprehension. This
produces the error message `list comprehension redefines %r from line %r` with
message args `[xx, 120]` (a list).
