### PR TITLE
Make sure that Checker does indeed ignore the names given in the "pyflakes_ignore" setting.

### DIFF
--- a/server/linter.py
+++ b/server/linter.py
@@ -88,15 +88,7 @@ def pyflakes_check(code, filename, ignore=None):
         return [PythonError(filename, 0, e.args[0])]
     else:
         # Okay, it's syntactically valid.  Now check it.
-        if ignore is not None:
-            old_magic_globals = pyflakes._MAGIC_GLOBALS
-            pyflakes._MAGIC_GLOBALS += ignore
-
-        w = pyflakes.Checker(tree, filename)
-
-        if ignore is not None:
-            pyflakes._MAGIC_GLOBALS = old_magic_globals
-
+        w = pyflakes.Checker(tree, filename, builtins=ignore)
         return w.messages
 
 


### PR DESCRIPTION
PyFlakes' Checker wasn't honoring the "pyflakes_ignore" setting. Instead of modifying a global, use Checker's "builtins" parameter when calling its constructor.
