### PR TITLE
add mouse shortcut for goto definition a la SublimeCodeIntel

### DIFF
--- a/Default (Linux).sublime-mousemap
+++ b/Default (Linux).sublime-mousemap
@@ -1,0 +1,3 @@
+[
+	{ "button": "button1", "modifiers": ["alt"], "command": "python_goto_definition", "press_command": "drag_select" }
+]

--- a/Default (OSX).sublime-mousemap
+++ b/Default (OSX).sublime-mousemap
@@ -1,0 +1,3 @@
+[
+	{ "button": "button1", "modifiers": ["ctrl"], "command": "python_goto_definition", "press_command": "drag_select" }
+]

--- a/Default (Windows).sublime-mousemap
+++ b/Default (Windows).sublime-mousemap
@@ -1,0 +1,3 @@
+[
+	{ "button": "button1", "modifiers": ["alt"], "command": "python_goto_definition", "press_command": "drag_select" }
+]


### PR DESCRIPTION
usage: hold alt/ctrl (depending on os) + left click a python name,
settable in Preferences > Package Settings > SublimePythonIDE > Mouse Bindings - Default/User
