### PR TITLE
Don't try to retrieve completions for apparently non-Python expressions

### DIFF
--- a/sublime_python_commands.py
+++ b/sublime_python_commands.py
@@ -12,6 +12,11 @@ class PythonCompletionsListener(sublime_plugin.EventListener):
 
     @python_only
     def on_query_completions(self, view, prefix, locations):
+        # Skip all prefixes ending with non-ASCII characters, since otherwise
+        # it lags insanely while typing in non-English strings.
+        if prefix and ord(prefix[-1]) > 128:
+            return []
+
         path = file_or_buffer_name(view)
         source = view.substr(sublime.Region(0, view.size()))
         loc = view.rowcol(locations[0])


### PR DESCRIPTION
For some reason the completion listener experienced insane lags when typing in non-ASCII characters, e.g. in Russian.

I haven't tried to identify the root cause of the issue yet, since this workaround seems to be enough to fix the plugins performance issue with long non-English docstrings. 
