### PR TITLE
Support multi-argument Pythons (like `env python`)

### DIFF
--- a/sublime_python.py
+++ b/sublime_python.py
@@ -128,10 +128,10 @@ class Proxy(object):
             elif SERVER_DEBUGGING:
                 # debug mode two
                 self.port = self.get_free_port()
-                proc_args = [self.python, SERVER_SCRIPT,
+                proc_args = self.python + [SERVER_SCRIPT,
                              str(self.port), " --debug"]
                 self.proc = subprocess.Popen(
-                    proc_args, cwd=os.path.dirname(self.python),
+                    proc_args, cwd=os.path.dirname(self.python[0]),
                     stderr=subprocess.PIPE, creationflags=CREATION_FLAGS)
                 self.queue = Queue()
                 self.stderr_reader = AsynchronousFileReader(
@@ -144,9 +144,9 @@ class Proxy(object):
             else:
                 # standard run of the server in end-user mode
                 self.port = self.get_free_port()
-                proc_args = [self.python, SERVER_SCRIPT, str(self.port)]
+                proc_args = self.python + [SERVER_SCRIPT, str(self.port)]
                 self.proc = subprocess.Popen(
-                    proc_args, cwd=os.path.dirname(self.python),
+                    proc_args, cwd=os.path.dirname(self.python[0]),
                     creationflags=CREATION_FLAGS)
                 print("started server on port %i with %s" %
                       (self.port, self.python))
@@ -300,35 +300,67 @@ def project_venv_python(view):
         return python
 
 
+def shebang_line_python(view):
+    shebang_line = view.substr(view.line(0))
+    if shebang_line.startswith('#!'):
+        return shebang_line[2:].split(None, 1)
+
+
+def normalize_path(args, make_abs=False):
+    if not args:
+        return None
+    elif type(args) is str:
+        args = [args]
+    elif type(args) is not list:
+        args = list(args)
+
+    # args is guaranteed to be a non-empty list at this point
+    if make_abs:
+        args[0] = os.path.abspath(os.path.realpath(os.path.expanduser(args[0])))
+    return args
+
+
 def proxy_for(view):
     '''retrieve an existing proxy for an external Python process.
-    will automatically create a new proxy if non exists for the
+    will automatically create a new proxy if none exists for the
     requested interpreter'''
     proxy = None
     with PROXY_LOCK:
-        python = get_setting("python_interpreter", view, "")
-        if python == "":
-            python = project_venv_python(view) or system_python()
-        else:
-            python = os.path.abspath(
-                os.path.realpath(os.path.expanduser(python)))
+        pythons = (
+            normalize_path(get_setting("python_interpreter", view, ""), True),
+            normalize_path(project_venv_python(view)),
+            normalize_path(shebang_line_python(view)),
+            normalize_path(system_python()),
+        )
 
-        if not os.path.exists(python):
+        python = pythons[0] or pythons[1] or pythons[2] or pythons[3]
+
+        if not python or not os.path.exists(python[0]):
             raise OSError("""
 --------------------------------------------------------------------------------------------------------------
 Could not detect python, please set the python_interpreter (see README) using an absolute path or make sure a
-system python is installed and is reachable on the PATH.
---------------------------------------------------------------------------------------------------------------""")
+system python is installed and is reachable on the PATH. Here is the order in which paths are tried:
 
-        if python in PROXIES:
-            proxy = PROXIES[python]
+ - By "python_interpreter" Sublime settings: %r
+ - By auto-detecting venv: %r
+ - By #! (shebang) line in this file: %r
+ - By auto-detecting system Python: %r
+
+We use the first non-None value and ensure that the path exists before proceeding.
+--------------------------------------------------------------------------------------------------------------"""
+        % pythons)
+
+        # Since lists cannot be used as keys, a temporary tuple version of this is created.
+        python_as_key = tuple(python)
+        if python_as_key in PROXIES:
+            proxy = PROXIES[python_as_key]
         else:
             try:
                 proxy = Proxy(python)
             except OSError:
                 pass
             else:
-                PROXIES[python] = proxy
+                PROXIES[python_as_key] = proxy
     return proxy
 
 


### PR DESCRIPTION
The changes in this commit add support for things like `#!/usr/bin/env python3` and make errors easier to find. Here are the details:

1. **Support multi-argument Python interpreters**

   Many people specify a Python interpreter with a line like this: `/usr/bin/env python3`. However, SublimePythonIDE allows only to specify the path to a Python interpreter. This would be less portable: Python 3 might be at `/usr/bin/python3` on one system and `/usr/local/bin/python3` on another. This commit makes it possible.

   How: This commit changes the python interpreter path (the thing named `python` in `proxy_for()` and `self.python` in `Proxy`) to be a list of strings instead of a single string. This allows for multi-argument Pythons to be specified by any of the Python path providers, including `get_setting("python_interpreter")` (aka, the `python_interpreter` setting can now be a list).

   This change is backwards-compatible: Python providers that emit a string will have it converted into the correct format (`"/usr/bin/python" -> ["/usr/bin/python"]`). A new function, `normalize_path`, makes normalizing easier.

2. **Auto-detect Python interpreter from shebang line**

   Perhaps the most common place to add such a Python interpreter specification is in the shebang (`#!`) line. This commit will choose the Python interpreter based on this.

   JulianEberius/SublimePythonIDE/pull/61 tried to do this earlier, but without support for multi-argument Pythons, it was forced to resolve the path to the actual Python. As such, it only worked for absolute paths to Python and `env` and for `env` it had to simulate `env`'s behavior (it "simulated" this by assuming Python is always in the same directory as `env`).

   This change is backwards-compatible: If the first line of the current file does not start with `#!`, the other Python path providers are tried.

3. **More informative error messages**

   This commit makes the "Could not detect python" message more informative by indicating which paths were tried. Here's an example:
   <img width="784" src="https://cloud.githubusercontent.com/assets/1570168/11181148/d40ce048-8c14-11e5-9990-f010174455f5.png">