### PR TITLE
Improve "Python not found dialog"

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,8 @@ I also added a lot caching throughout the underlying Rope library which improved
 Configuration
 -------------
 
+## Python location
+
 The only necessary configuration is pointing SublimePythonIDE at the correct Python interpreter to use.
 There are four mechanisms for detecting Python that are used in the following order:
 
@@ -39,6 +41,13 @@ The option "python_interpreter" can be set in the projects settings (Project->Ed
     }
 
 This is also the way to select a virtualenv (point it to the interpreter in the venv) and thus get the completions/definitions for you project working.
+
+To suppress the "Could not find Python dialog", save the following setting:
+
+    "suppress_python_not_found_error": false,
+
+
+## Imports location
 
 SublimePythonIDE will also look up imports relative to the project root directory (the top directory of your project).
 


### PR DESCRIPTION
Improve "Python not found dialog"

| Old | New |
| --- | --- |
| <img width="420" src="https://cloud.githubusercontent.com/assets/1570168/11857670/2a416ce2-a40f-11e5-9032-a07122bcb120.png"> | <img width="522" src="https://cloud.githubusercontent.com/assets/1570168/11857668/2a2d7db8-a40f-11e5-95ef-9da27016735b.png"> |

| New |
| --- |
| <img width="602" src="https://cloud.githubusercontent.com/assets/1570168/11857669/2a2dc854-a40f-11e5-99a4-cf29366c7885.png"> |

Rationale and changes:
- Permanent actions without a clear "undo" button are confusing for new users.
  Change: The "Don't show this again" button is moved to a more "dangerous" location (where "Don't Save", a destructive action, normally appears)
- Modals can get really annoying, and some people will expect to open files with badly configured Pythons and not be faced with a modal.
  Change: Add an setting "suppress_python_not_found_error" to permanently turn off modals
  Change: Always error to console, even if modal turned off, for advanced users
- Change: aesthetic changes to dialog
- Change: add link to documentation
- Users might not know who is responsible for the dialog
  Change: Add plugin name in dialog
