### PR TITLE
Feature: use jedi for `definition_location` instead of rope

### DIFF
--- a/SublimePython.sublime-settings
+++ b/SublimePython.sublime-settings
@@ -40,5 +40,8 @@
     "pyflakes_ignore": [],
 
     // If the organize imports refactoring should be called on every file save
-    "python_organize_imports_on_save": false
+    "python_organize_imports_on_save": false,
+
+    // Which lookup method to use; one of "rope" / "jedi-assignment" / "jedi-definition"
+    "definition_lookup_method": "rope"
 }

--- a/server/server.py
+++ b/server/server.py
@@ -223,10 +223,14 @@ class RopeFunctionsMixin(object):
 
         real_path, def_lineno = (None, None)
         try:
-            def_resource, def_lineno = get_definition_location(
-                project, source, loc, resource=resource, maxfixes=3)
-            if def_resource:
-                real_path = def_resource.real_path
+            row, col = loc
+            script = jedi.Script(source, row + 1, col, file_path)
+            definitions = script.goto_assignments()
+            # definitions = script.goto_definitions()
+            if definitions:
+                logging.debug(definitions)
+                real_path = definitions[0].module_path
+                def_lineno = definitions[0].start_pos[0]
         except ModuleSyntaxError:
             pass
 

--- a/sublime_python_commands.py
+++ b/sublime_python_commands.py
@@ -134,8 +134,10 @@ class PythonGotoDefinitionCommand(sublime_plugin.WindowCommand):
         proxy = proxy_for(view)
         if not proxy:
             return
+        lookup_method = get_setting("definition_lookup_method", default_value='rope')
         def_result = proxy.definition_location(
-            source, root_folder_for(view), path, view.rowcol(view.sel()[0].a))
+            source, root_folder_for(view), path, view.rowcol(view.sel()[0].a),
+            lookup_method)
 
         if not def_result or def_result == [None, None]:
             return

--- a/sublime_python_commands.py
+++ b/sublime_python_commands.py
@@ -129,18 +129,13 @@ class PythonGotoDefinitionCommand(sublime_plugin.WindowCommand):
     @python_only
     def run(self, *args):
         view = self.window.active_view()
-        row, col = view.rowcol(view.sel()[0].a)
-        offset = view.text_point(row, col)
         path = file_or_buffer_name(view)
         source = view.substr(sublime.Region(0, view.size()))
-        if view.substr(offset) in [u'(', u')']:
-            offset = view.text_point(row, col - 1)
-
         proxy = proxy_for(view)
         if not proxy:
             return
         def_result = proxy.definition_location(
-            source, root_folder_for(view), path, offset)
+            source, root_folder_for(view), path, view.rowcol(view.sel()[0].a))
 
         if not def_result or def_result == [None, None]:
             return


### PR DESCRIPTION
For me, the main reason for this change is that Jedi has support for following `flask.ext` imports.

Jedi's functionality differs from rope in (at least) one noticeable way:
- **Rope** immediately follows a symbol through an import if no assignment exists in current source
- **Jedi** has 2 different methods [documented in it's API](http://jedi.jedidjah.ch/en/latest/docs/plugin-api.html#jedi.api.Script):
  - `goto_assignments` that resolves until assignment (never auto-following imports out of current file)
  - `goto_definition` which does auto-follow, but always until the very end (up to a module/class/function definition).

I tried both, and `goto_assignments` feels more natural to me, since it stops on each assignment/import, and I can choose to keep following or not.

I've made the method settable in settings with all 3 options: `rope/jedi-assignemnts/jedi-definitions`.

I kept the previous `rope` as the default behaviour, but I would advocate changing the default to `jedi-assignments`. While this may surprise current SublimePythonIDE users since it will now require _another click_ each time an import statement is reached, I believe this explicit behavior is more correct and that using Jedi outweighs the "new interface learning curve".

@JulianEberius Please let me know how you feel, and I'll make adjustments accordingly.
