### PR TITLE
[Fixed] Generate new color scheme

### DIFF
--- a/sublime_python_colors.py
+++ b/sublime_python_colors.py
@@ -136,4 +136,4 @@ def update_color_scheme(colors):
         sublime.save_settings("Preferences.sublime-settings")
 
     # run async
-    sublime.set_timeout_async(generate_color_scheme_async, 0)
+    # sublime.set_timeout_async(generate_color_scheme_async, 0)


### PR DESCRIPTION
See also [**similar pull request**](https://github.com/SublimeLinter/SublimeLinter3/pull/534).

### 1. Behavior before pull request

New color scheme `User/SashaSublime (SublimePythonIDE).tmTheme` create and replace current color scheme in `User/Preferences.sublime-settings` after Sublime Text restart.

### 2. Behavior after pull request

New color scheme don't generate and don't replace current color scheme.

### 3. Reasons

1. [**Users may well manually**](https://github.com/Kristinita/SashaSublime/blob/SashaDevelop/SashaSublime.tmTheme#L2543-L2581) add [**these lines**](https://github.com/JulianEberius/SublimePythonIDE/blob/master/sublime_python_colors.py#L14-L54) in tmTheme file of user preferred scheme.
2. I am color scheme developer. Each time, when I need to change my color scheme, I need change in my `User/Preferences.sublime-settings` file `"color_scheme": "Packages/SashaSublime/SashaSublime.tmTheme"` to `Packages/User/SashaSublime (SublimePythonIDE).tmTheme`. It takes a lot of time.
3. Some Sublime Text packages also generate own color schemes. Examples:

+ [**PersistentRegexHighlight**](https://github.com/skuroda/PersistentRegexHighlight/issues/22),
+ [**Color Highlighter**](https://github.com/Monnoroch/ColorHighlighter/issues/325),
+ [**SublimeLinter3**](https://github.com/SublimeLinter/SublimeLinter3/pull/534),
+ [**Colorcoder**](https://github.com/vprimachenko/Sublime-Colorcoder).

Each of these packages create own color scheme. But user may use one color scheme. Color changes of other packages don't applied.

4. I think, is a bad practice — impose user file your color scheme without the user's permission.

### 4. Alternative

You may add option `generate_new_color_scheme_file` in settings. If `false`, new color scheme file don't generate.

Thanks.